### PR TITLE
Use hashtag for comments

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        // symbol used for single line comment
+        "lineComment": "#"
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Kivy uses hastags for comments, therefore updating language-configuration.json to use a hashtag.
No mechanism for block comments.

Resolves issue #2 