### PR TITLE
Highlight only first occurence of string with colon

### DIFF
--- a/syntaxes/kv.tmLanguage.json
+++ b/syntaxes/kv.tmLanguage.json
@@ -26,7 +26,7 @@
         {
             "comment": "Keys: Indention followed by : and a value",
             "name": "support.variable.kv",
-            "match": "^.*:"
+            "match": "^(.*?):"
         },
         {
             "comment": "Double quoted strings",


### PR DESCRIPTION
Updated the regex to be non-greedy so that it will stop capturing after the first occurrence of a colon.

Resolves issue #6