### PR TITLE
Add kv language support within Python files + fixes for comments in kv

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,16 @@
                 "language": "kivy",
                 "scopeName": "source.kv",
                 "path": "./syntaxes/kv.tmLanguage.json"
+            },
+            {
+                "injectTo": [
+                    "source.python"
+                ],
+                "scopeName": "styled",
+                "path": "./syntaxes/kv.json",
+                "embeddedLanguages": {
+                    "source.kv": "kv"
+                }
             }
         ],
         "snippets": [

--- a/syntaxes/kv.json
+++ b/syntaxes/kv.json
@@ -1,0 +1,18 @@
+{
+	"fileTypes": ["py"],
+	"injectionSelector": "L:source",
+	"patterns": [
+		{
+			"contentName": "source.kv",
+			"begin": "Builder\\.load_string\\(\\w*(\"\"\"|''')",
+			"end": "\\w*(\\1)",
+			"patterns": [
+				{
+					"include": "source.kv"
+				}
+			]
+		}
+	],
+	"scopeName": "styled"
+}
+

--- a/syntaxes/kv.tmLanguage.json
+++ b/syntaxes/kv.tmLanguage.json
@@ -5,7 +5,7 @@
         {
             "comment": "Global value: #:set name value is equivalent to name = value",
             "name": "comment.line.number-sign.kv",
-            "match": "#:.*"
+            "match": "#:?.*"
         },
         {
             "comment": "Root rule (There can only be one!): No indention followed by :",
@@ -21,12 +21,12 @@
         {
             "comment": "Children widgets: Indention followed by :",
             "name": "entity.name.function.kv",
-            "match": "^.*:$"
+            "match": "^[^#]*:$"
         },
         {
             "comment": "Keys: Indention followed by : and a value",
             "name": "support.variable.kv",
-            "match": "^(.*?):"
+            "match": "^([^#]*?):"
         },
         {
             "comment": "Double quoted strings",


### PR DESCRIPTION
It now supports in Python blocks such as:
```python
Builder.load_string("""
...
""")
```

And also correct comments that wasn't working correctly if there is indentation at the start.