### PR TITLE
Updated regex for class rule

### DIFF
--- a/syntaxes/kv.tmLanguage.json
+++ b/syntaxes/kv.tmLanguage.json
@@ -15,8 +15,7 @@
         {
             "comment": "Class rule: Declared by the name of a widget class between < > and followed by :",
             "name": "entity.name.type.kv",
-            "begin": "<",
-            "end": ">:"
+            "match": "^<.*>:$"
         },
         {
             "comment": "Children widgets: Indention followed by :",


### PR DESCRIPTION
Updated regex for class rule to look only for less-than and greater-than signs, which doesn't allow
it to begin with spaces.

Helps resolve issue #18

Change-Id: I0082d5133c99d225a302851b49c0f6e0c4f55c78